### PR TITLE
Issue with regular expressions global search

### DIFF
--- a/tests.html
+++ b/tests.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Tests</title>
+	<script src="../dojo/dojo/dojo.js" type="text/javascript" djConfig="isDebug: true"></script>
+	<script src="urldispatch.js" ></script>
+</head>
+<body>
+	<script>
+	dojo.require("doh.runner");
+	dojo.require("urldispatch");
+	dojo.require("doh.runner");
+	dojo.require("doh._browserRunner");
+	dojo.require("dojox.testing.DocTest");
+	
+	doh.register("t",[
+		function test_regex_fix(t){
+			var test_views = {
+					root : 0,
+					hello : 0
+				},
+				routes = [
+          ['!/', function() {
+						test_views.root++;
+					}, 'home'],
+	        ['!/hello', function() {
+						test_views.hello++
+					}, 'hello']
+		    ],
+				dispatcher = new urldispatch.Dispatcher(routes);
+				
+				t.is(0, test_views.root);
+				dispatcher.dispatch("!/");
+				t.is(1, test_views.root);
+				dispatcher.dispatch("!/hello");
+				t.is(1, test_views.root);
+				t.is(1, test_views.hello);
+				dispatcher.dispatch("!/");
+				t.is(2, test_views.root);
+				t.is(1, test_views.hello);
+				dispatcher.dispatch("!/hello");
+				t.is(2, test_views.root);
+				t.is(2, test_views.hello);
+				dispatcher.dispatch("!/");
+				t.is(3, test_views.root);
+				t.is(2, test_views.hello);
+				console.log("Tests complete!");
+		}
+	]);
+	dojo.addOnLoad(function(){
+		doh.run()
+	});
+	</script>
+</body>
+</html>

--- a/urldispatch.js
+++ b/urldispatch.js
@@ -48,7 +48,7 @@ dojo.declare('urldispatch.Dispatcher',
             //            private
             dojo.forEach(routes, dojo.hitch(this, function(route){
                 this._routes.push({
-                    pattern: new RegExp('^' + route[0].replace(/(:\w+)/, '(\\w+)') + '$', 'g'),
+                    pattern: new RegExp('^' + route[0].replace(/(:\w+)/, '(\\w+)') + '$'),
                     path: route[0],
                     view: route[1],
                     kwArgs: route[0].match(/:\w+/g),


### PR DESCRIPTION
I discovered an issue while I was playing with the url-dispatcher in that if you declare two routes, go to the first one, then go back, then click forward, you get a failure. If you attempt to click back and then forward again, it will work. Basically, the same regular expression was returning both a true and a false for the same test.

It turns out in JavaScript that if you use the global flag and perform a test on the regular expression, it stores the index in which it found the match (even if you're just calling a test). This ends up causing the second time you call the regular expression to start from somewhere else in the string (like the second character) which always causes it to fail.

I fixed the bug by removing the global identifier from that regular expression. It should not be necessary for the test action.

I also added a test to show it failing- You might want to try it out as it is then verify the result.

Hope you accept the pull request! Great concept for a plugin, by the way. I love the concept of routes with regards to the hash change.
